### PR TITLE
Noop returns null

### DIFF
--- a/src/mixin.js
+++ b/src/mixin.js
@@ -5,7 +5,7 @@
 
 import React from 'react';
 
-const noop = () => {};
+const noop = () => null;
 const es6ify = (mixin) => {
   if (typeof mixin === 'function') {
     // mixin is already es6 style


### PR DESCRIPTION
```
Warning: X.shouldComponentUpdate(): Returned undefined instead of a boolean value. Make sure to return true or false.`
```

Explicitly return null to suppress warnings?
