### PR TITLE
add support to ES7 static properties on react mixins

### DIFF
--- a/src/mixin.js
+++ b/src/mixin.js
@@ -17,7 +17,7 @@ const es6ify = (mixin) => {
     // convert to ES6 class
     class NewClass extends Base {}
 
-    const clonedMixin = {...mixin};
+    const clonedMixin = Object.assign({}, mixin);
     // These React properties are defined as ES7 class static properties
     [
       'childContextTypes', 'contextTypes',

--- a/src/mixin.js
+++ b/src/mixin.js
@@ -16,7 +16,18 @@ const es6ify = (mixin) => {
     // mixin is old-react style plain object
     // convert to ES6 class
     class NewClass extends Base {}
-    Object.assign(NewClass.prototype, mixin);
+
+    const clonedMixin = {...mixin};
+    // These React properties are defined as ES7 class static properties
+    [
+      'childContextTypes', 'contextTypes',
+      'defaultProps', 'propTypes'
+    ].forEach(m => {
+      NewClass[m] = clonedMixin[m];
+      delete clonedMixin[m];
+    });
+    Object.assign(NewClass.prototype, clonedMixin);
+
     return NewClass;
   };
 };

--- a/tests/mixin.spec.js
+++ b/tests/mixin.spec.js
@@ -123,3 +123,27 @@ describe('mixin', () => {
     assert.ok(testInstance.shouldComponentUpdate());
   });
 });
+
+describe('static property mixin support', () => {
+  const propTypes = {'test': true};
+
+  const es6Mixin = base => {
+    class newClass extends base {};
+    newClass.propTypes = propTypes;
+    return newClass;
+  }
+
+  const es5Mixin = {
+    propTypes: propTypes
+  };
+
+  it('upgrades ES6 properties', () => {
+    class Test extends mixin(es6Mixin) {}
+    assert.equal(Test.propTypes, propTypes);
+  });
+
+  it('upgrades ES5 properties', () => {
+    class Test extends mixin(es5Mixin) {}
+    assert.equal(Test.propTypes, propTypes);
+  })
+});


### PR DESCRIPTION
A quick look into React codebase reveals the following properties are defined as static properties for ES7 classes:
- mixins
- propTypes
- contextTypes
- childContextTypes
- defaultProps

Except for mixins which should be switched to use this higher-order class, I've add support to move those properties from mixin to constructor, rather than constructor's prototype.

I'm not sure if clone a mixin then delete those properties is the best solution for partial assignment, but I can't find clever solution with destructing either. Feel free to let me know if there's a better way to do this!
