### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ class MyComponent extends mixin(reactMixin) {
 }
 ```
 
-#Installation
+# Installation
 
 ```
 npm install es6-react-mixins
@@ -106,12 +106,12 @@ npm install es6-react-mixins
 
 The source is written in es6 but there's an npm prebublish step which transpiles to es5 and dumps into `lib` directory - which is the default import.
 
-#Testing
+# Testing
 
 ```
 npm test
 ```
 
-#Contributions
+# Contributions
 
 Yes please!


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
